### PR TITLE
Zenefits :: Singer Tap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 tests/cassettes
 .coverage
 *.DS_Store
+config*

--- a/poetry.lock
+++ b/poetry.lock
@@ -85,6 +85,14 @@ toml = "*"
 
 [[package]]
 category = "main"
+description = "Function decoration for backoff and retry"
+name = "backoff"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.8.0"
+
+[[package]]
+category = "main"
 description = "cChardet is high speed universal character encoding detector."
 name = "cchardet"
 optional = false
@@ -109,6 +117,14 @@ name = "chardet"
 optional = false
 python-versions = "*"
 version = "3.0.4"
+
+[[package]]
+category = "main"
+description = "Fast ISO8601 date time parser for Python written in C"
+name = "ciso8601"
+optional = false
+python-versions = "*"
+version = "2.1.3"
 
 [[package]]
 category = "main"
@@ -150,6 +166,17 @@ version = "5.5.3"
 colors = ["colorama (>=0.4.3,<0.5.0)"]
 pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 requirements_deprecated_finder = ["pipreqs", "pip-api"]
+
+[[package]]
+category = "main"
+description = "An implementation of JSON Schema validation for Python"
+name = "jsonschema"
+optional = false
+python-versions = "*"
+version = "2.6.0"
+
+[package.extras]
+format = ["rfc3987", "strict-rfc3339", "webcolors"]
 
 [[package]]
 category = "dev"
@@ -382,7 +409,7 @@ description = "World timezone definitions, modern and historical"
 name = "pytz"
 optional = false
 python-versions = "*"
-version = "2020.1"
+version = "2018.4"
 
 [[package]]
 category = "main"
@@ -391,6 +418,33 @@ name = "pyyaml"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "5.3.1"
+
+[[package]]
+category = "main"
+description = "Simple, fast, extensible JSON encoder/decoder for Python"
+name = "simplejson"
+optional = false
+python-versions = "*"
+version = "3.11.1"
+
+[[package]]
+category = "main"
+description = "Singer.io utility library"
+name = "singer-python"
+optional = false
+python-versions = "*"
+version = "5.9.0"
+
+[package.dependencies]
+backoff = "1.8.0"
+ciso8601 = "*"
+jsonschema = "2.6.0"
+python-dateutil = ">=2.6.0"
+pytz = "2018.4"
+simplejson = "3.11.1"
+
+[package.extras]
+dev = ["pylint", "ipython", "ipdb", "nose", "singer-tools"]
 
 [[package]]
 category = "main"
@@ -454,7 +508,7 @@ idna = ">=2.0"
 multidict = ">=4.0"
 
 [metadata]
-content-hash = "caf127922e17cc4d0eab8b127c012dc6978d2995d0b227be05ad4d1930d8d3ae"
+content-hash = "6ef8430eae0e8dc9b971395f537438444ab539a6cf6073dd6692b2157387232d"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -494,6 +548,10 @@ attrs = [
 ]
 autopep8 = [
     {file = "autopep8-1.5.4.tar.gz", hash = "sha256:d21d3901cb0da6ebd1e83fc9b0dfbde8b46afc2ede4fe32fbda0c7c6118ca094"},
+]
+backoff = [
+    {file = "backoff-1.8.0-py2.py3-none-any.whl", hash = "sha256:d340bb6f36d025c04214b8925112d8456970e5f28dda46e4f1133bf5c622cb0a"},
+    {file = "backoff-1.8.0.tar.gz", hash = "sha256:c7187f15339e775aec926dc6e5e42f8a3ad7d3c2b9a6ecae7b535000f70cd838"},
 ]
 cchardet = [
     {file = "cchardet-2.1.6-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:2aa1b008965c703ad6597361b0f6d427c8971fe94a2c99ec3724c228ae50d6a6"},
@@ -568,6 +626,9 @@ chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
     {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
 ]
+ciso8601 = [
+    {file = "ciso8601-2.1.3.tar.gz", hash = "sha256:bdbb5b366058b1c87735603b23060962c439ac9be66f1ae91e8c7dbd7d59e262"},
+]
 colorama = [
     {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
@@ -615,6 +676,10 @@ idna = [
 isort = [
     {file = "isort-5.5.3-py3-none-any.whl", hash = "sha256:c16eaa7432a1c004c585d79b12ad080c6c421dd18fe27982ca11f95e6898e432"},
     {file = "isort-5.5.3.tar.gz", hash = "sha256:6187a9f1ce8784cbc6d1b88790a43e6083a6302f03e9ae482acc0f232a98c843"},
+]
+jsonschema = [
+    {file = "jsonschema-2.6.0-py2.py3-none-any.whl", hash = "sha256:000e68abd33c972a5248544925a0cae7d1125f9bf6c58280d37546b946769a08"},
+    {file = "jsonschema-2.6.0.tar.gz", hash = "sha256:6ff5f3180870836cae40f06fa10419f557208175f13ad7bc26caa77beb1f6e02"},
 ]
 lazy-object-proxy = [
     {file = "lazy-object-proxy-1.4.3.tar.gz", hash = "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"},
@@ -796,8 +861,8 @@ python-dotenv = [
     {file = "python_dotenv-0.14.0-py2.py3-none-any.whl", hash = "sha256:c10863aee750ad720f4f43436565e4c1698798d763b63234fb5021b6c616e423"},
 ]
 pytz = [
-    {file = "pytz-2020.1-py2.py3-none-any.whl", hash = "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed"},
-    {file = "pytz-2020.1.tar.gz", hash = "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"},
+    {file = "pytz-2018.4-py2.py3-none-any.whl", hash = "sha256:65ae0c8101309c45772196b21b74c46b2e5d11b6275c45d251b150d5da334555"},
+    {file = "pytz-2018.4.tar.gz", hash = "sha256:c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749"},
 ]
 pyyaml = [
     {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
@@ -811,6 +876,28 @@ pyyaml = [
     {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
     {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
+]
+simplejson = [
+    {file = "simplejson-3.11.1-cp27-cp27m-win32.whl", hash = "sha256:38c2b563cd03363e7cb2bbba6c20ae4eaafd853a83954c8c8dd345ee391787bf"},
+    {file = "simplejson-3.11.1-cp27-cp27m-win_amd64.whl", hash = "sha256:8d73b96a6ee7c81fd49dac7225e3846fd60b54a0b5b93a0aaea04c5a5d2e7bf2"},
+    {file = "simplejson-3.11.1-cp33-cp33m-win32.whl", hash = "sha256:7f53ab6a675594f237ce7372c1edf742a6acb158149ed3259c5fffc5b613dc94"},
+    {file = "simplejson-3.11.1-cp33-cp33m-win_amd64.whl", hash = "sha256:86aa9fd492230c4b8b6814fcf089b36ffba2cec4d0635c8c642135b9067ebbd7"},
+    {file = "simplejson-3.11.1-cp34-cp34m-win32.whl", hash = "sha256:7df76ae6cac4a62ad5295f9a9131857077d84cb15fad2011acb2ce7410476009"},
+    {file = "simplejson-3.11.1-cp34-cp34m-win_amd64.whl", hash = "sha256:a6939199c30b78ae31e62e6913f0e12cb71a4a5ad67c259e0a98688df027a5de"},
+    {file = "simplejson-3.11.1-cp35-cp35m-win32.whl", hash = "sha256:11d91b88cc1e9645c79f0f6fd2961684249af963e2bbff5a00061ed4bbf55379"},
+    {file = "simplejson-3.11.1-cp35-cp35m-win_amd64.whl", hash = "sha256:36b0de42e3a8a51086c339cc803f6ac7a9d1d5254066d680956a195ca12cf0d8"},
+    {file = "simplejson-3.11.1.tar.gz", hash = "sha256:01a22d49ddd9a168b136f26cac87d9a335660ce07aa5c630b8e3607d6f4325e7"},
+    {file = "simplejson-3.11.1.win-amd64-py2.7.exe", hash = "sha256:1975e6b621fe1c2b9321c56476e8ebe1b851006517c1d67041b378950374694c"},
+    {file = "simplejson-3.11.1.win-amd64-py3.3.exe", hash = "sha256:f60f01b16215568a08611eb6a4d61d76c4173c3d69aac9cad593777056c284d5"},
+    {file = "simplejson-3.11.1.win-amd64-py3.4.exe", hash = "sha256:6be48181337ac5f5d9f48c9c504f317e245519318992122a05c40e482a721d59"},
+    {file = "simplejson-3.11.1.win-amd64-py3.5.exe", hash = "sha256:8ae8cdcbe49e29ddfdae0ab81c1f6c070706d18fcee86371352d0d54b47ad8ec"},
+    {file = "simplejson-3.11.1.win32-py2.7.exe", hash = "sha256:ebbd52b59948350ad66205e66b299fcca0e0821ed275c21262c522f4a6cea9d2"},
+    {file = "simplejson-3.11.1.win32-py3.3.exe", hash = "sha256:2dc7fb8c0c0ff9483ce31b93b700b1fa60aca9d099e6aca9813f28ff131ccf59"},
+    {file = "simplejson-3.11.1.win32-py3.4.exe", hash = "sha256:97cc43ef4cb18a2725f6e26d22b96f8ca50872a195bde32707dcb284f89c1d4d"},
+    {file = "simplejson-3.11.1.win32-py3.5.exe", hash = "sha256:c76d55d78dc8b06c96fd08c6cc5e2b0b650799627d3f9ca4ad23f40db72d5f6d"},
+]
+singer-python = [
+    {file = "singer-python-5.9.0.tar.gz", hash = "sha256:54b85914389312db9cf7b2800829e2d1a4b2d5a43a96d677d2a35311499d37c7"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pytest-asyncio = "^0.14.0"
 coverage = "^5.3"
 pytest-cov = "^2.10.1"
 pandas = "^1.1.2"
+singer-python = "^5.9.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/tap_zenefits/catalog.json
+++ b/tap_zenefits/catalog.json
@@ -1,0 +1,304 @@
+{
+  "streams": [
+    {
+      "tap_stream_id": "people",
+      "stream": "people",
+      "key_properties": ["id"],
+      "schema": {
+        "additionalProperties": false,
+        "properties": {
+        "banks": {
+          "object": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ref_object": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "city": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "company": {
+          "object": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ref_object": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "country": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "date_of_birth": null,
+        "department": {
+          "object": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ref_object": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "employments": {
+          "object": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ref_object": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "first_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "preferred_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "employee_number": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "last_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "location": {
+          "object": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ref_object": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "manager": {
+          "object": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ref_object": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "object": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "postal_code": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "state": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "street1": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "street2": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "subordinates": {
+          "object": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ref_object": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "work_email": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "personal_email": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "work_phone": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "personal_phone": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "gender": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "personal_pronoun": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "photo_url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "photo_thumbnail_url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "federal_filing_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "social_security_number": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+        },
+        "type": [
+          "null",
+          "object"
+        ]
+      },
+      "metadata": []
+    }
+  ]
+}

--- a/tap_zenefits/catalog.json
+++ b/tap_zenefits/catalog.json
@@ -7,296 +7,158 @@
       "schema": {
         "additionalProperties": false,
         "properties": {
-        "banks": {
+          "banks": {
+            "object": {
+              "type": ["string", "null"]
+            },
+            "ref_object": {
+              "type": ["string", "null"]
+            },
+            "url": {
+              "type": ["string", "null"]
+            }
+          },
+          "city": {
+            "type": ["string", "null"]
+          },
+          "company": {
+            "object": {
+              "type": ["string", "null"]
+            },
+            "ref_object": {
+              "type": ["string", "null"]
+            },
+            "url": {
+              "type": ["string", "null"]
+            }
+          },
+          "country": {
+            "type": ["string", "null"]
+          },
+          "date_of_birth": null,
+          "department": {
+            "object": {
+              "type": ["string", "null"]
+            },
+            "ref_object": {
+              "type": ["string", "null"]
+            },
+            "url": {
+              "type": ["string", "null"]
+            }
+          },
+          "employments": {
+            "object": {
+              "type": ["string", "null"]
+            },
+            "ref_object": {
+              "type": ["string", "null"]
+            },
+            "url": {
+              "type": ["string", "null"]
+            }
+          },
+          "first_name": {
+            "type": ["string", "null"]
+          },
+          "preferred_name": {
+            "type": ["string", "null"]
+          },
+          "id": {
+            "type": ["string", "null"]
+          },
+          "employee_number": {
+            "type": ["string", "null"]
+          },
+          "last_name": {
+            "type": ["string", "null"]
+          },
+          "location": {
+            "object": {
+              "type": ["string", "null"]
+            },
+            "ref_object": {
+              "type": ["string", "null"]
+            },
+            "url": {
+              "type": ["string", "null"]
+            }
+          },
+          "manager": {
+            "object": {
+              "type": ["string", "null"]
+            },
+            "ref_object": {
+              "type": ["string", "null"]
+            },
+            "url": {
+              "type": ["string", "null"]
+            }
+          },
           "object": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
-          "ref_object": {
-            "type": [
-              "string",
-              "null"
-            ]
+          "postal_code": {
+            "type": ["string", "null"]
           },
-          "url": {
-            "type": [
-              "string",
-              "null"
-            ]
+          "state": {
+            "type": ["string", "null"]
+          },
+          "status": {
+            "type": ["string", "null"]
+          },
+          "street1": {
+            "type": ["string", "null"]
+          },
+          "street2": {
+            "type": ["string", "null"]
+          },
+          "subordinates": {
+            "object": {
+              "type": ["string", "null"]
+            },
+            "ref_object": {
+              "type": ["string", "null"]
+            },
+            "url": {
+              "type": ["string", "null"]
+            }
+          },
+          "title": {
+            "type": ["string", "null"]
+          },
+          "work_email": {
+            "type": ["string", "null"]
+          },
+          "personal_email": {
+            "type": ["string", "null"]
+          },
+          "work_phone": {
+            "type": ["string", "null"]
+          },
+          "personal_phone": {
+            "type": ["string", "null"]
+          },
+          "gender": {
+            "type": ["string", "null"]
+          },
+          "personal_pronoun": {
+            "type": ["string", "null"]
+          },
+          "photo_url": {
+            "type": ["string", "null"]
+          },
+          "photo_thumbnail_url": {
+            "type": ["string", "null"]
+          },
+          "federal_filing_status": {
+            "type": ["string", "null"]
+          },
+          "social_security_number": {
+            "type": ["string", "null"]
           }
         },
-        "city": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "company": {
-          "object": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "ref_object": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "url": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "country": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "date_of_birth": null,
-        "department": {
-          "object": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "ref_object": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "url": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "employments": {
-          "object": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "ref_object": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "url": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "first_name": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "preferred_name": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "id": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "employee_number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "last_name": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "location": {
-          "object": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "ref_object": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "url": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "manager": {
-          "object": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "ref_object": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "url": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "object": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "postal_code": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "state": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "status": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "street1": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "street2": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "subordinates": {
-          "object": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "ref_object": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "url": {
-            "type": [
-              "string",
-              "null"
-            ]
-          }
-        },
-        "title": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "work_email": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "personal_email": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "work_phone": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "personal_phone": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "gender": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "personal_pronoun": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "photo_url": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "photo_thumbnail_url": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "federal_filing_status": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "social_security_number": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-        },
-        "type": [
-          "null",
-          "object"
-        ]
+        "type": ["null", "object"]
       },
       "metadata": []
     }

--- a/tap_zenefits/departments_schema.py
+++ b/tap_zenefits/departments_schema.py
@@ -1,0 +1,40 @@
+import json
+
+
+class Departments:
+    schema = {
+        "properties": {
+            "company": {
+                "object": {
+                    "type": ["string", "null"]
+                },
+                "ref_object": {
+                    "type": ["string", "null"]
+                },
+                "url": {
+                    "type": ["string", "null"]
+                }
+            },
+            "id": {
+                "type": ["string", "null"],
+                "key": True
+            },
+            "name": {
+                "type": ["string", "null"]
+            },
+            "object": {
+                "type": ["string", "null"]
+            },
+            "people": {
+                "object": {
+                    "type": ["string", "null"]
+                },
+                "ref_object": {
+                    "type": ["string", "null"]
+                },
+                "url": {
+                    "type": ["string", "null"]
+                }
+            }
+        },
+    }

--- a/tap_zenefits/employments_schema.py
+++ b/tap_zenefits/employments_schema.py
@@ -1,0 +1,52 @@
+import json
+
+class Employments:
+  schema = {
+      "properties": {
+          "annual_salary": {
+              "type": ["string", "null"]
+          },
+          "comp_type": {
+              "type": ["string", "null"]
+          },
+          "employment_type": {
+              "type": ["string", "null"]
+          },
+          "hire_date": {
+              "type": ["string", "null"]
+          },
+          "id": {
+              "type": ["string", "null"],
+              "key": True
+          },
+          "object": {
+              "type": ["string", "null"]
+          },
+          "pay_rate": {
+              "type": ["string", "null"]
+          },
+          "person": {
+              "object": {
+                  "type": ["string", "null"]
+              },
+              "ref_object": {
+                  "type": ["string", "null"]
+              },
+              "url": {
+                  "type": ["string", "null"]
+              }
+          },
+          "termination_date": {
+              "type": ["string", "null"]
+          },
+          "termination_type": {
+              "type": ["string", "null"]
+          },
+          "working_hours_per_week": {
+              "type": ["string", "null"]
+          },
+          "is_active": {
+              "type": ["string", "null"]
+          }
+      }
+  }

--- a/tap_zenefits/pay_stubs_schema.py
+++ b/tap_zenefits/pay_stubs_schema.py
@@ -1,9 +1,9 @@
 import json
 
+
 class PayStubs:
-  schema = {
-    "properties": {
-        {
+    schema = {
+        "properties": {
             "object": {
                 "type": ["string", "null"]
             },
@@ -159,9 +159,9 @@ class PayStubs:
                         "type": ["string", "null"]
                     },
                     "labor_group_ids": {
-                            "": {
-                                "type": ["string", "null"]
-                            }
+                        "": {
+                            "type": ["string", "null"]
+                        }
                     }
                 },
                 {
@@ -178,9 +178,9 @@ class PayStubs:
                         "type": ["string", "null"]
                     },
                     "labor_group_ids": {
-                            "": {
-                                "type": ["string", "null"]
-                            }
+                        "": {
+                            "type": ["string", "null"]
+                        }
                     }
                 },
                 {
@@ -197,12 +197,12 @@ class PayStubs:
                         "type": ["string", "null"]
                     },
                     "labor_group_ids": {
-                            "group1": {
-                                "type": ["string", "null"]
-                            },
-                            "group2": {
-                                "type": ["string", "null"]
-                            }
+                        "group1": {
+                            "type": ["string", "null"]
+                        },
+                        "group2": {
+                            "type": ["string", "null"]
+                        }
                     }
                 }
             ],
@@ -221,12 +221,12 @@ class PayStubs:
                         "type": ["string", "null"]
                     },
                     "labor_group_ids": {
-                            "group1": {
-                                "type": ["string", "null"]
-                            },
-                            "group2": {
-                                "type": ["string", "null"]
-                            }
+                        "group1": {
+                            "type": ["string", "null"]
+                        },
+                        "group2": {
+                            "type": ["string", "null"]
+                        }
                     }
                 },
                 {
@@ -243,12 +243,12 @@ class PayStubs:
                         "type": ["string", "null"]
                     },
                     "labor_group_ids": {
-                            "group1": {
-                                "type": ["string", "null"]
-                            },
-                            "group2": {
-                                "type": ["string", "null"]
-                            }
+                        "group1": {
+                            "type": ["string", "null"]
+                        },
+                        "group2": {
+                            "type": ["string", "null"]
+                        }
                     }
                 }
             ],
@@ -267,12 +267,12 @@ class PayStubs:
                         "type": ["string", "null"]
                     },
                     "labor_group_ids": {
-                            "group1": {
-                                "type": ["string", "null"]
-                            },
-                            "group2": {
-                                "type": ["string", "null"]
-                            }
+                        "group1": {
+                            "type": ["string", "null"]
+                        },
+                        "group2": {
+                            "type": ["string", "null"]
+                        }
                     }
                 },
                 {
@@ -289,12 +289,12 @@ class PayStubs:
                         "type": ["string", "null"]
                     },
                     "labor_group_ids": {
-                            "group1": {
-                                "type": ["string", "null"]
-                            },
-                            "group2": {
-                                "type": ["string", "null"]
-                            }
+                        "group1": {
+                            "type": ["string", "null"]
+                        },
+                        "group2": {
+                            "type": ["string", "null"]
+                        }
                     }
                 },
             ],
@@ -316,12 +316,12 @@ class PayStubs:
                         "type": ["string", "null"]
                     },
                     "labor_group_ids": {
-                            "group1": {
-                                "type": ["string", "null"]
-                            },
-                            "group2": {
-                                "type": ["string", "null"]
-                            }
+                        "group1": {
+                            "type": ["string", "null"]
+                        },
+                        "group2": {
+                            "type": ["string", "null"]
+                        }
                     }
                 }
             ],
@@ -340,12 +340,12 @@ class PayStubs:
                         "type": ["string", "null"]
                     },
                     "labor_group_ids": {
-                            "group1": {
-                                "type": ["string", "null"]
-                            },
-                            "group2": {
-                                "type": ["string", "null"]
-                            }
+                        "group1": {
+                            "type": ["string", "null"]
+                        },
+                        "group2": {
+                            "type": ["string", "null"]
+                        }
                     }
                 },
                 {
@@ -362,12 +362,12 @@ class PayStubs:
                         "type": ["string", "null"]
                     },
                     "labor_group_ids": {
-                            "group1": {
-                                "type": ["string", "null"]
-                            },
-                            "group2": {
-                                "type": ["string", "null"]
-                            }
+                        "group1": {
+                            "type": ["string", "null"]
+                        },
+                        "group2": {
+                            "type": ["string", "null"]
+                        }
                     }
                 }
             ],
@@ -386,12 +386,12 @@ class PayStubs:
                         "type": ["string", "null"]
                     },
                     "labor_group_ids": {
-                            "group1": {
-                                "type": ["string", "null"]
-                            },
-                            "group2": {
-                                "type": ["string", "null"]
-                            }
+                        "group1": {
+                            "type": ["string", "null"]
+                        },
+                        "group2": {
+                            "type": ["string", "null"]
+                        }
                     }
                 },
                 {
@@ -408,12 +408,12 @@ class PayStubs:
                         "type": ["string", "null"]
                     },
                     "labor_group_ids": {
-                            "group1": {
-                                "type": ["string", "null"]
-                            },
-                            "group2": {
-                                "type": ["string", "null"]
-                            }
+                        "group1": {
+                            "type": ["string", "null"]
+                        },
+                        "group2": {
+                            "type": ["string", "null"]
+                        }
                     }
                 },
                 {
@@ -430,12 +430,12 @@ class PayStubs:
                         "type": ["string", "null"]
                     },
                     "labor_group_ids": {
-                            "group1": {
-                                "type": ["string", "null"]
-                            },
-                            "group2": {
-                                "type": ["string", "null"]
-                            }
+                        "group1": {
+                            "type": ["string", "null"]
+                        },
+                        "group2": {
+                            "type": ["string", "null"]
+                        }
                     }
                 }
             ],
@@ -454,6 +454,6 @@ class PayStubs:
                 "type": ["string", "null"],
                 "key": True
             }
-        },
+
+        }
     }
-  }

--- a/tap_zenefits/pay_stubs_schema.py
+++ b/tap_zenefits/pay_stubs_schema.py
@@ -1,0 +1,459 @@
+import json
+
+class PayStubs:
+  schema = {
+    "properties": {
+        {
+            "object": {
+                "type": ["string", "null"]
+            },
+            "person": {
+                "url": {
+                    "type": ["string", "null"]
+                },
+                "object": {
+                    "type": ["string", "null"]
+                },
+                "ref_object": {
+                    "type": ["string", "null"]
+                }
+            },
+            "url": {
+                "type": ["string", "null"]
+            },
+            "summary": {
+                "gross_pay": {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    }
+                },
+                "regular_earnings": {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    }
+                },
+                "company_contributions": {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    }
+                },
+                "person_deductions": {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    }
+                },
+                "garnishments": {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    }
+                },
+                "company_taxes": {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    }
+                },
+                "person_taxes": {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    }
+                },
+                "imputed_pay": {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    }
+                },
+                "reported_tips": {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    }
+                },
+                "reimbursements": {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    }
+                },
+                "cash_tips": {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    }
+                },
+            },
+            "earnings": [
+                {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "name": {
+                        "type": ["string", "null"]
+                    },
+                    "labor_group_ids": {
+                            "": {
+                                "type": ["string", "null"]
+                            }
+                    }
+                },
+                {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "name": {
+                        "type": ["string", "null"]
+                    },
+                    "labor_group_ids": {
+                            "": {
+                                "type": ["string", "null"]
+                            }
+                    }
+                },
+                {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "name": {
+                        "type": ["string", "null"]
+                    },
+                    "labor_group_ids": {
+                            "group1": {
+                                "type": ["string", "null"]
+                            },
+                            "group2": {
+                                "type": ["string", "null"]
+                            }
+                    }
+                }
+            ],
+            "company_contributions": [
+                {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "name": {
+                        "type": ["string", "null"]
+                    },
+                    "labor_group_ids": {
+                            "group1": {
+                                "type": ["string", "null"]
+                            },
+                            "group2": {
+                                "type": ["string", "null"]
+                            }
+                    }
+                },
+                {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "name": {
+                        "type": ["string", "null"]
+                    },
+                    "labor_group_ids": {
+                            "group1": {
+                                "type": ["string", "null"]
+                            },
+                            "group2": {
+                                "type": ["string", "null"]
+                            }
+                    }
+                }
+            ],
+            "person_deductions": [
+                {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "name": {
+                        "type": ["string", "null"]
+                    },
+                    "labor_group_ids": {
+                            "group1": {
+                                "type": ["string", "null"]
+                            },
+                            "group2": {
+                                "type": ["string", "null"]
+                            }
+                    }
+                },
+                {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "name": {
+                        "type": ["string", "null"]
+                    },
+                    "labor_group_ids": {
+                            "group1": {
+                                "type": ["string", "null"]
+                            },
+                            "group2": {
+                                "type": ["string", "null"]
+                            }
+                    }
+                },
+            ],
+            "garnishments": [
+                {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "category": {
+                        "type": ["string", "null"]
+                    },
+                    "name": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    },
+                    "labor_group_ids": {
+                            "group1": {
+                                "type": ["string", "null"]
+                            },
+                            "group2": {
+                                "type": ["string", "null"]
+                            }
+                    }
+                }
+            ],
+            "company_taxes": [
+                {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "name": {
+                        "type": ["string", "null"]
+                    },
+                    "labor_group_ids": {
+                            "group1": {
+                                "type": ["string", "null"]
+                            },
+                            "group2": {
+                                "type": ["string", "null"]
+                            }
+                    }
+                },
+                {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "name": {
+                        "type": ["string", "null"]
+                    },
+                    "labor_group_ids": {
+                            "group1": {
+                                "type": ["string", "null"]
+                            },
+                            "group2": {
+                                "type": ["string", "null"]
+                            }
+                    }
+                }
+            ],
+            "person_taxes": [
+                {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "name": {
+                        "type": ["string", "null"]
+                    },
+                    "labor_group_ids": {
+                            "group1": {
+                                "type": ["string", "null"]
+                            },
+                            "group2": {
+                                "type": ["string", "null"]
+                            }
+                    }
+                },
+                {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "name": {
+                        "type": ["string", "null"]
+                    },
+                    "labor_group_ids": {
+                            "group1": {
+                                "type": ["string", "null"]
+                            },
+                            "group2": {
+                                "type": ["string", "null"]
+                            }
+                    }
+                },
+                {
+                    "amount_type": {
+                        "type": ["string", "null"]
+                    },
+                    "ytd_amount": {
+                        "type": ["string", "null"]
+                    },
+                    "amount": {
+                        "type": ["string", "null"]
+                    },
+                    "name": {
+                        "type": ["string", "null"]
+                    },
+                    "labor_group_ids": {
+                            "group1": {
+                                "type": ["string", "null"]
+                            },
+                            "group2": {
+                                "type": ["string", "null"]
+                            }
+                    }
+                }
+            ],
+            "payrun": {
+                "url": {
+                    "type": ["string", "null"]
+                },
+                "object": {
+                    "type": ["string", "null"]
+                },
+                "ref_object": {
+                    "type": ["string", "null"]
+                }
+            },
+            "id": {
+                "type": ["string", "null"],
+                "key": True
+            }
+        },
+    }
+  }

--- a/tap_zenefits/payruns_schema.py
+++ b/tap_zenefits/payruns_schema.py
@@ -1,0 +1,58 @@
+import json
+
+
+class Payruns:
+    schema = {
+        "properties": {
+            "company": {
+                "url": {
+                    "type": ["string", "null"]
+                },
+                "object": {
+                    "type": ["string", "null"]
+                },
+                "ref_object": {
+                    "type": ["string", "null"]
+                }
+            },
+            "check_date": {
+                "type": ["string", "null"]
+            },
+            "original_check_date": {
+                "type": ["string", "null"]
+            },
+            "payrun_type": {
+                "type": ["string", "null"]
+            },
+            "status": {
+                "type": ["string", "null"]
+            },
+            "start_date": {
+                "type": ["string", "null"]
+            },
+            "end_date": {
+                "type": ["string", "null"]
+            },
+            "people": {
+                "url": {
+                    "type": ["string", "null"]
+                },
+                "object": {
+                    "type": ["string", "null"]
+                },
+                "ref_object": {
+                    "type": ["string", "null"]
+                }
+            },
+            "url": {
+                "type": ["string", "null"]
+            },
+            "object": {
+                "type": ["string", "null"]
+            },
+            "id": {
+                "type": ["string", "null"],
+                "key": True
+            }
+        }
+    }

--- a/tap_zenefits/people_schema.py
+++ b/tap_zenefits/people_schema.py
@@ -1,0 +1,162 @@
+import json
+
+
+class People:
+    schema = {
+        "properties": {
+            "banks": {
+                "object": {
+                    "type": ["string", "null"]
+                },
+                "ref_object": {
+                    "type": ["string", "null"]
+                },
+                "url": {
+                    "type": ["string", "null"]
+                }
+            },
+            "city": {
+                "type": ["string", "null"]
+            },
+            "company": {
+                "object": {
+                    "type": ["string", "null"]
+                },
+                "ref_object": {
+                    "type": ["string", "null"]
+                },
+                "url": {
+                    "type": ["string", "null"]
+                }
+            },
+            "country": {
+                "type": ["string", "null"]
+            },
+            "date_of_birth": {
+                "type": ["string", "null"]
+            },
+            "department": {
+                "object": {
+                    "type": ["string", "null"]
+                },
+                "ref_object": {
+                    "type": ["string", "null"]
+                },
+                "url": {
+                    "type": ["string", "null"]
+                }
+            },
+            "employments": {
+                "object": {
+                    "type": ["string", "null"]
+                },
+                "ref_object": {
+                    "type": ["string", "null"]
+                },
+                "url": {
+                    "type": ["string", "null"]
+                }
+            },
+            "first_name": {
+                "type": ["string", "null"]
+            },
+            "preferred_name": {
+                "type": ["string", "null"]
+            },
+            "id": {
+                "type": ["string", "null"],
+                "key": True
+            },
+            "employee_number": {
+                "type": ["string", "null"]
+            },
+            "last_name": {
+                "type": ["string", "null"]
+            },
+            "location": {
+                "object": {
+                    "type": ["string", "null"]
+                },
+                "ref_object": {
+                    "type": ["string", "null"]
+                },
+                "url": {
+                    "type": ["string", "null"]
+                }
+            },
+            "manager": {
+                "object": {
+                    "type": ["string", "null"]
+                },
+                "ref_object": {
+                    "type": ["string", "null"]
+                },
+                "url": {
+                    "type": ["string", "null"]
+                }
+            },
+            "object": {
+                "type": ["string", "null"]
+            },
+            "postal_code": {
+                "type": ["string", "null"]
+            },
+            "state": {
+                "type": ["string", "null"]
+            },
+            "status": {
+                "type": ["string", "null"]
+            },
+            "street1": {
+                "type": ["string", "null"]
+            },
+            "street2": {
+                "type": ["string", "null"]
+            },
+            "subordinates": {
+                "object": {
+                    "type": ["string", "null"]
+                },
+                "ref_object": {
+                    "type": ["string", "null"]
+                },
+                "url": {
+                    "type": ["string", "null"]
+                }
+            },
+            "title": {
+                "type": ["string", "null"]
+            },
+            "work_email": {
+                "type": ["string", "null"]
+            },
+            "personal_email": {
+                "type": ["string", "null"]
+            },
+            "work_phone": {
+                "type": ["string", "null"]
+            },
+            "personal_phone": {
+                "type": ["string", "null"]
+            },
+            "gender": {
+                "type": ["string", "null"]
+            },
+            "personal_pronoun": {
+                "type": ["string", "null"]
+            },
+            "photo_url": {
+                "type": ["string", "null"]
+            },
+            "photo_thumbnail_url": {
+                "type": ["string", "null"]
+            },
+            "federal_filing_status": {
+                "type": ["string", "null"]
+            },
+            "social_security_number": {
+                "type": ["string", "null"]
+            }
+        },
+    }
+

--- a/tap_zenefits/schema_classes.py
+++ b/tap_zenefits/schema_classes.py
@@ -1,0 +1,6 @@
+from tap_zenefits.people_schema import People
+from tap_zenefits.payruns_schema import Payruns
+from tap_zenefits.pay_stubs_schema import PayStubs
+from tap_zenefits.employments_schema import Employments
+from tap_zenefits.departments_schema import Departments
+from tap_zenefits.time_durations_schema import TimeDurations

--- a/tap_zenefits/time_durations_schema.py
+++ b/tap_zenefits/time_durations_schema.py
@@ -1,0 +1,74 @@
+import json
+
+class TimeDurations:
+  schema = {
+      "properties": {
+          "person": {
+              "url": {
+                  "type": ["string", "null"]
+              },
+              "object": {
+                  "type": ["string", "null"]
+              },
+              "ref_object": {
+                  "type": ["string", "null"]
+              }
+          },
+          "activity": {
+              "type": ["string", "null"]
+          },
+          "state": {
+              "type": ["string", "null"]
+          },
+          "valid_status": {
+              "type": ["string", "null"]
+          },
+          "hours": {
+              "type": ["string", "null"]
+          },
+          "date": {
+              "type": ["string", "null"]
+          },
+          "start": {
+              "type": ["string", "null"]
+          },
+          "end": {
+              "type": ["string", "null"]
+          },
+          "is_overnight": {
+              "type": ["string", "null"]
+          },
+          "is_approved": {
+              "type": ["string", "null"]
+          },
+          "approved_datetime": {
+              "type": ["string", "null"]
+          },
+          "approver": {
+              "url": {
+                  "type": ["string", "null"]
+              },
+              "object": {
+                  "type": ["string", "null"]
+              },
+              "ref_object": {
+                  "type": ["string", "null"]
+              }
+          },
+          "labor_group_ids": {
+              "group1": {
+                  "type": ["string", "null"]
+              }
+          },
+          "url": {
+              "type": ["string", "null"]
+          },
+          "object": {
+              "type": ["string", "null"]
+          },
+          "id": {
+              "type": ["string", "null"],
+              "key": True
+          }
+      },
+  }

--- a/tap_zenefits/zenefits.py
+++ b/tap_zenefits/zenefits.py
@@ -8,12 +8,8 @@ import pandas as pd
 import pprint
 import singer
 from datetime import datetime, timezone
-from people_schema import People
-from payruns_schema import Payruns
-from pay_stubs_schema import PayStubs
-from employments_schema import Employments
-from departments_schema import Departments
-from time_durations_schema import TimeDurations
+from schema_classes import People, Payruns, PayStubs, Employments, Departments, TimeDurations
+
 
 person = People()
 payrun = Payruns()
@@ -44,7 +40,10 @@ async def fetch_endpoint(endpoint_name):
             "time_durations": await fetch_time_durations(client)
         }
 
-        return endpoints[endpoint_name]
+        try:
+            return endpoints[endpoint_name]
+        except KeyError:
+            return "Key not found. Please enter a valid endpoint: people, payruns, pay_stubs, employments, departments, time_durations"
 
 
 async def fetch_all_endpoints():
@@ -126,4 +125,4 @@ async def fetch_time_durations(client):
 
 
 loop = asyncio.get_event_loop()
-api_response = loop.run_until_complete(fetch_endpoint("people"))
+loop.run_until_complete(fetch_endpoint("people"))

--- a/tap_zenefits/zenefits.py
+++ b/tap_zenefits/zenefits.py
@@ -6,6 +6,9 @@ import os
 from collections import defaultdict
 import pandas as pd
 import pprint
+import singer
+from datetime import datetime, timezone
+
 
 pp = pprint.PrettyPrinter(indent=4, depth=3)
 

--- a/tap_zenefits/zenefits.py
+++ b/tap_zenefits/zenefits.py
@@ -8,8 +8,7 @@ import pandas as pd
 import pprint
 import singer
 from datetime import datetime, timezone
-from schema_classes import People, Payruns, PayStubs, Employments, Departments, TimeDurations
-
+from .schema_classes import People, Payruns, PayStubs, Employments, Departments, TimeDurations
 
 person = People()
 payrun = Payruns()

--- a/tap_zenefits/zenefits.py
+++ b/tap_zenefits/zenefits.py
@@ -8,13 +8,15 @@ import pandas as pd
 import pprint
 import singer
 from datetime import datetime, timezone
+from people_schema import People
 
+person = People()
 
 pp = pprint.PrettyPrinter(indent=4, depth=3)
 
-load_dotenv()
-company_id = json.loads(os.getenv("dandelion_chocolate"))['company_id']
-API_KEY = json.loads(os.getenv("dandelion_chocolate"))['token']
+args = singer.utils.parse_args(["token", "company_id"])
+company_id = args.config['company_id']
+API_KEY = args.config['token']
 
 headers = {
     'Authorization': API_KEY
@@ -24,6 +26,13 @@ headers = {
 async def fetch_endpoint():
     async with aiohttp.ClientSession() as client:
         response = await fetch_people(client, company_id)
+
+        singer.write_schema('people', person.schema, 'id')
+        singer.write_records('people', response["data"]["data"])
+
+        # The code below is an alternative option to iterate through the response if necessary.
+        # for record in response["data"]["data"]:
+            # singer.write_records('people', record)
         
         return response
 


### PR DESCRIPTION
# Description :: User Story

This PR adds Singer tap functionality. 

- When called each endpoint now includes `singer.write_schema` and `singer.write_records`
  - This allows each endpoint to be called individually if necessary
- The `fetch_endpoint(endpoint_name)` function now accepts an `endpoint_name` argument
  - This argument is used to determine which endpoint function to call
- The `company_id` and `API_KEY` are now set by command line args when running the tap

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Breaking Change
- [x] Testing

## Environment and Dependencies

- [x] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [ ] No Changes

Details:
- Added `singer-python` package

## Pull Request Notes

All functionality works as expected. However, tests are currently failing because there are no command-line arguments being passed into Pytest to set the `company_id` and `API_KEY`. I'm currently determining the best way to update the test suite to include the necessary command-line arguments.

## Pytest Results and Coverage

```txt
Paste Coverage.py results here
```
